### PR TITLE
fix: correct mssql import in db.ts so connection pool works

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,5 @@
-import { sql } from "mssql";
-
-let pool: sql.sqlConnectionPool | null = null;
+import sql from "mssql";
+let pool: sql.ConnectionPool | null = null;
 
 const config = {
   server: process.env.DB_SERVER,


### PR DESCRIPTION
The named import `import { sql } from "mssql"` returned `undefined` because the mssql package doesn't expose `sql` as a named export. This caused `sql.connect(config)` to throw `Cannot read properties of undefined (reading 'connect')` on every request that tried to query the database.

Changed the import to a default import: `import sql from "mssql"` and updated the pool type annotation: `sql.sqlConnectionPool` → `sql.ConnectionPool` (the original type didn't exist)